### PR TITLE
Add support for displaying snowflakes as long form base64 strings

### DIFF
--- a/src/FlakeId.Tests/IdExtensionsTests.cs
+++ b/src/FlakeId.Tests/IdExtensionsTests.cs
@@ -2,39 +2,47 @@
 using FlakeId.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace FlakeId.Tests
+namespace FlakeId.Tests;
+
+[TestClass]
+public class IdExtensionsTests
 {
-    [TestClass]
-    public class IdExtensionsTests
+    [TestMethod]
+    public void Id_ToDateTimeOffset()
     {
-        [TestMethod]
-        public void Id_ToDateTimeOffset()
-        {
-            var id = Id.Create();
-            var timeStamp = id.ToDateTimeOffset();
-            var now = DateTimeOffset.Now;
-            var delta = now - timeStamp;
+        Id id = Id.Create();
+        DateTimeOffset timeStamp = id.ToDateTimeOffset();
+        DateTimeOffset now = DateTimeOffset.Now;
+        TimeSpan delta = now - timeStamp;
 
-            Assert.IsTrue(delta.Seconds <= 1);
-        }
+        Assert.IsTrue(delta.Seconds <= 1);
+    }
 
-        [TestMethod]
-        public void Id_ToUnixTimeMilliseconds()
-        {
-            var id = Id.Create();
-            long timestamp = id.ToUnixTimeMilliseconds();
-            long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            
-            Assert.IsTrue(now - timestamp < 100);
-        }
+    [TestMethod]
+    public void Id_ToUnixTimeMilliseconds()
+    {
+        Id id = Id.Create();
+        long timestamp = id.ToUnixTimeMilliseconds();
+        long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-        [TestMethod]
-        public void Id_IsValid()
-        {
-            var id = Id.Create();
-            bool isValid = id.IsSnowflake();
+        Assert.IsTrue(now - timestamp < 100);
+    }
 
-            Assert.IsTrue(isValid);
-        }
+    [TestMethod]
+    public void Id_IsValid()
+    {
+        Id id = Id.Create();
+        bool isValid = id.IsSnowflake();
+
+        Assert.IsTrue(isValid);
+    }
+
+    [TestMethod]
+    public void Id_ToStringIdentifier_ProducesValidId()
+    {
+        Id id = Id.Create();
+        string s = id.ToStringIdentifier();
+
+        Assert.AreNotEqual(default, s);
     }
 }

--- a/src/FlakeId/Extensions/IdExtensions.cs
+++ b/src/FlakeId/Extensions/IdExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 namespace FlakeId.Extensions
 {
@@ -27,6 +28,13 @@ namespace FlakeId.Extensions
             long increment = id & 0b111111111111;
 
             return timestamp > 0 && thread > 0 && process > 0 && increment > 0;
+        }
+
+        public static string ToStringIdentifier(this Id id)
+        {
+            string identifier = id.ToString();
+
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(identifier));
         }
     }
 }


### PR DESCRIPTION
FlakeIds are problematic with clients that are powered by v8. This includes NodeJS in backend services, and most (if not all) JavaScript clients and browsers. These runtimes support 56 bit floating point numbers as opposed to the 64 bit integers FlakeId is based on.

To alleviate this, serving applications can call `ToString()` on a FlakeId, and serve the ID as a string to their clients. This is inherently dangerous, as the client will observe this ID to be a number, and may therefore parse it as such. This parse operation will be successful and the client will be in the possession of a `number` ID.

However, because this number is lacking (very important) 8 bits, it is no longer guaranteed to be unique and will sooner or later collide. This is an *extremely* pernicious bug that could have disastrous consequences, such as retrieving the wrong customer information from an external service, or worse.

Therefore, this PR introduces an alternate `ToString()` method in the form of a `ToStringIdentifier()` extension method, which takes the textual bytes of the FlakeId, and returns them in base64 format. This base64 identifier can then freely be passed around, similar to YouTube video IDs. They're a lot longer, though.
