### PR TITLE
IsSnowflake wrongly returns false

### DIFF
--- a/src/FlakeId.Tests/IdTests.cs
+++ b/src/FlakeId.Tests/IdTests.cs
@@ -4,106 +4,72 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace FlakeId.Tests
+namespace FlakeId.Tests;
+
+[TestClass]
+public class IdTests
 {
-    [TestClass]
-    public class IdTests
+    [TestMethod]
+    public void Id_Create()
     {
-        [TestMethod]
-        public void Id_Create()
+        Id id = Id.Create();
+
+        Assert.IsTrue(id > 1);
+    }
+
+    [TestMethod]
+    public void Id_CreateManyFast()
+    {
+        Id[] ids = Enumerable.Range(0, 1000).Select(_ => Id.Create()).ToArray();
+
+        foreach (Id id in ids)
         {
-            var id = Id.Create();
-            
-            Assert.IsTrue(id > 1);
+            Assert.IsTrue(ids.Count(i => i == id) == 1);
+        }
+    }
+
+    [TestMethod]
+    public async Task Id_CreateManyDelayed()
+    {
+        List<Id> ids = new();
+
+        for (int i = 0; i < 100; i++)
+        {
+            ids.Add(Id.Create());
+            await Task.Delay(TimeSpan.FromMilliseconds(5));
         }
 
-        [TestMethod]
-        public void Id_CreateManyFast()
+        foreach (Id id in ids)
         {
-            var ids = Enumerable.Range(0, 1000).Select(_ => Id.Create()).ToArray();
-
-            foreach (var id in ids)
-                Assert.IsTrue(ids.Count(i => i == id) == 1);
+            Assert.IsTrue(ids.Count(i => i == id) == 1);
         }
+    }
 
-        [TestMethod]
-        public async Task Id_CreateManyDelayed()
-        {
-            List<Id> ids = new();
+    [TestMethod]
+    public void Id_Equality()
+    {
+        // This test should never fail so long as Id is a struct.
+        Id left = new(5956206959003041793);
+        Id right = new(5956206959003041793);
 
-            for (int i = 0; i < 100; i++)
-            {
-                ids.Add(Id.Create());
-                await Task.Delay(TimeSpan.FromMilliseconds(5));
-            }
-            
-            foreach (var id in ids)
-                Assert.IsTrue(ids.Count(i => i == id) == 1);
-        }
+        Assert.AreEqual(left, right);
+    }
 
-        [TestMethod]
-        public void Id_Equality()
-        {
-            // This test should never fail so long as Id is a struct.
-            var left = new Id(5956206959003041793);
-            var right = new Id(5956206959003041793);
-            
-            Assert.AreEqual(left, right);
-        }
+    [TestMethod]
+    public void Id_Sortable()
+    {
+        // The sequence in which Ids are generated should be equal to a set of sorted Ids.
+        Id[] ids = Enumerable.Range(0, 1000).Select(_ => Id.Create()).ToArray();
+        Id[] sorted = ids.OrderBy(i => i).ToArray();
 
-        [TestMethod]
-        public void Id_Sortable()
-        {
-            // The sequence in which Ids are generated should be equal to a set of sorted Ids.
-            var ids = Enumerable.Range(0, 1000).Select(_ => Id.Create()).ToArray();
-            var sorted = ids.OrderBy(i => i).ToArray();
-            
-            Assert.IsTrue(ids.SequenceEqual(sorted));
-        }
+        Assert.IsTrue(ids.SequenceEqual(sorted));
+    }
 
-        [TestMethod]
-        public void Id_Parse_Invalid()
-        {
-            const long value = 10;
+    [TestMethod]
+    public void Id_ToString()
+    {
+        long id = Id.Create();
 
-            Assert.ThrowsException<FormatException>(() => Id.Parse(value));
-        }
-
-        [TestMethod]
-        public void Id_Parse()
-        {
-            long id = Id.Create();
-
-            Id.Parse(id);
-        }
-
-        [TestMethod]
-        public void Id_TryParse_Invalid()
-        {
-            const long value = 10;
-
-            bool parse = Id.TryParse(value, out _);
-
-            Assert.IsFalse(parse);
-        }
-
-        [TestMethod]
-        public void Id_TryParse()
-        {
-            long id = Id.Create();
-
-            bool parse = Id.TryParse(id, out var parsed);
-
-            Assert.IsTrue(parse);
-            Assert.AreEqual(id, parsed);
-        }
-
-        [TestMethod]
-        public void Id_ToString()
-        {
-            long id = Id.Create();
-
-            Assert.AreEqual(((long)id).ToString(), id.ToString());
-        }
+        Assert.AreEqual(id.ToString(), id.ToString());
     }
 }

--- a/src/FlakeId.Tests/ParseTests.cs
+++ b/src/FlakeId.Tests/ParseTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FlakeId.Tests;
+
+[TestClass]
+public class ParseTests
+{
+
+
+    [TestMethod]
+    public void Id_Parse_Invalid()
+    {
+        const long value = 10;
+
+        Assert.ThrowsException<FormatException>(() => Id.Parse(value));
+    }
+
+    [TestMethod]
+    public void Id_Parse()
+    {
+        long id = Id.Create();
+
+        Id.Parse(id);
+    }
+
+    [TestMethod]
+    public void Id_TryParse_Invalid()
+    {
+        const long value = 10;
+
+        bool parse = Id.TryParse(value, out _);
+
+        Assert.IsFalse(parse);
+    }
+
+    [TestMethod]
+    public void Id_TryParse()
+    {
+        long id = Id.Create();
+
+        bool parse = Id.TryParse(id, out Id parsed);
+
+        Assert.IsTrue(parse);
+        Assert.AreEqual(id, parsed);
+    }
+
+    [TestMethod]
+    public void Id_TryParse_Many()
+    {
+        List<Id> ids = Enumerable.Range(0, 100_000).Select(_ => Id.Create()).ToList();
+        List<Id> problematic = new();
+
+        bool failed = false;
+        foreach (var id in ids)
+        {
+            if (!Id.TryParse(id, out Id parsed))
+            {
+                Debug.WriteLine(id);
+                problematic.Add(id);
+                failed = true;
+            }
+        }
+
+        Assert.IsFalse(failed);
+    }
+
+    [TestMethod]
+    public void Id_TryParse_Problematic()
+    {
+        Id id = Id.Parse(1108047973760811023);
+    }
+}

--- a/src/FlakeId/Extensions/IdExtensions.cs
+++ b/src/FlakeId/Extensions/IdExtensions.cs
@@ -5,10 +5,8 @@ namespace FlakeId.Extensions
 {
     public static class IdExtensions
     {
-        public static DateTimeOffset ToDateTimeOffset(this Id id)
-        {
-            return DateTimeOffset.FromUnixTimeMilliseconds(id.ToUnixTimeMilliseconds());
-        }
+        public static DateTimeOffset ToDateTimeOffset(this Id id) =>
+            DateTimeOffset.FromUnixTimeMilliseconds(id.ToUnixTimeMilliseconds());
 
         public static long ToUnixTimeMilliseconds(this Id id)
         {
@@ -23,11 +21,11 @@ namespace FlakeId.Extensions
             // The closest we can get is by decomposing its components, and ensuring all of them are set
             // to values that would be valid for a snowflake.
             long timestamp = id >> 22;
-            long thread = id >> 17 & 0b11111;
-            long process = id >> 12 & 0b11111;
+            long thread = (id >> 17) & 0b11111;
+            long process = (id >> 12) & 0b11111;
             long increment = id & 0b111111111111;
 
-            return timestamp > 0 && thread > 0 && process > 0 && increment > 0;
+            return timestamp > 0 && thread > 0 && process > 0 && increment >= 0;
         }
 
         public static string ToStringIdentifier(this Id id)


### PR DESCRIPTION
For sample set 

```
1108047352848760832
1108047352848760832
1108047352848760832
1108047352848760832
1108047352852955136
1108047352852955136
1108047352852955136
1108047352852955136
1108047352852955136
1108047352857149440
1108047352857149440
1108047352857149440
1108047352857149440
1108047352857149440
1108047352861343744
1108047352861343744
1108047352861343744
1108047352861343744
1108047352861343744
1108047352865538048
1108047352865538048
1108047352865538048
1108047352865538048
1108047352869732352
```

`IsSnowflake()` will wrongly return false because the increment component of the ID is `0`. This PR addresses this issue and increases test coverage.

More info in #6 