### PR TITLE
CRITICAL Incorrect application of interlocked increment

### DIFF
--- a/src/FlakeId/Id.cs
+++ b/src/FlakeId/Id.cs
@@ -147,9 +147,7 @@ namespace FlakeId
                 s_processId = Process.GetCurrentProcess().Id & ProcessIdMask;
             int processId = s_processId.Value;
 
-            Interlocked.Increment(ref s_increment);
-
-            int increment = s_increment & IncrementMask;
+            int increment = Interlocked.Increment(ref s_increment) & IncrementMask;
 
             unchecked
             {


### PR DESCRIPTION
The static integer might be incremented additionally between the atomic operation and its application in a parallel scenario. It is the result of the atomic operation, which contains the correct value. 

https://learn.microsoft.com/en-us/dotnet/api/system.threading.interlocked.increment?view=net-8.0

Returns
[UInt32](https://learn.microsoft.com/en-us/dotnet/api/system.uint32?view=net-8.0)

**The value of the variable immediately after the increment operation finished.**
