### PR TITLE
Add ToBase64String method for URL-safe Base64 encoding and parsing for Id

### DIFF
--- a/src/FlakeId/Extensions/IdExtensions.cs
+++ b/src/FlakeId/Extensions/IdExtensions.cs
@@ -47,14 +47,152 @@ namespace FlakeId.Extensions
 
         /// <summary>
         ///     Returns the specified ID as a base 64 encoded string, useful when exposing 64 bit IDs to Node or v8 applications.
+        ///     This method uses the legacy implementation, which first converts the ID to a decimal string and then Base64-encodes it.
+        ///     For improved performance, shorter output, and standard Base64 encoding, use <see cref="ToBase64String(Id)"/> instead.
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
+        [Obsolete(
+            "This legacy method produces longer, non-standard Base64 IDs. Prefer ToBase64String() for compact and standard IDs."
+        )]
         public static string ToStringIdentifier(this Id id)
         {
             string identifier = id.ToString();
 
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(identifier));
+        }
+
+        /// <summary>
+        ///     Returns the specified ID as a URL-safe Base64 encoded string, useful when exposing 64 bit IDs to web applications.
+        ///     This method directly encodes the 64-bit value as Base64, making it more efficient.
+        ///     The result is URL-safe (uses '-' and '_' instead of '+' and '/') and has no padding.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public static string ToBase64String(this Id id)
+        {
+            long value = id;
+            byte[] bytes = BitConverter.GetBytes(value);
+
+            // convert bytes to a base64 string. remove padding and replace symbols to ensure result is URL safe
+            return Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+        }
+
+        /// <summary>
+        ///     Parses a Base64-encoded string back to an ID. This method can handle both the new URL-safe format
+        ///     (from <see cref="ToBase64String(Id)"/>) and the legacy format (from <see cref="ToStringIdentifier(Id)"/>).
+        /// </summary>
+        /// <param name="base64String">The Base64-encoded string to parse</param>
+        /// <returns>The parsed ID</returns>
+        /// <exception cref="ArgumentException">Thrown when the string cannot be parsed as a valid ID</exception>
+        public static Id FromBase64String(string base64String)
+        {
+            if (string.IsNullOrEmpty(base64String))
+                throw new ArgumentException(
+                    "Base64 string cannot be null or empty",
+                    nameof(base64String)
+                );
+
+            try
+            {
+                // try parse the new url-safe format first
+                if (TryParseFromUrlSafeBase64(base64String, out Id id))
+                    return id;
+
+                // fall back to legacy format
+                if (TryParseFromLegacyBase64(base64String, out id))
+                    return id;
+
+                // neither method could parse the base 64 string, throw exception
+                throw new ArgumentException("Invalid Base64 string format", nameof(base64String));
+            }
+            catch (Exception ex) when (!(ex is ArgumentException))
+            {
+                throw new ArgumentException(
+                    "Invalid Base64 string format",
+                    nameof(base64String),
+                    ex
+                );
+            }
+        }
+
+        /// <summary>
+        ///     Tries to parse a URL-safe Base64 string into an <see cref="Id"/>.
+        ///     Returns true if parsing succeeds; otherwise returns false and sets <paramref name="id"/> to <see cref="default(Id)"/>.
+        /// </summary>
+        /// <param name="base64String">The URL-safe Base64 string to parse.</param>
+        /// <param name="id">The resulting <see cref="Id"/> if successful; otherwise <see cref="default(Id)"/>.</param>
+        /// <returns>True if the string was a valid 64-bit ID; false otherwise.</returns>
+        private static bool TryParseFromUrlSafeBase64(string base64String, out Id id)
+        {
+            id = default;
+
+            try
+            {
+                // restore url safe characters and padding
+                string standardBase64 = base64String.Replace('-', '+').Replace('_', '/');
+
+                // add padding to make the string length a multiple of 4 (needed for base64)
+                switch (standardBase64.Length % 4)
+                {
+                    case 2: standardBase64 += "=="; break;
+                    case 3: standardBase64 += "="; break;
+                }
+
+                byte[] bytes = Convert.FromBase64String(standardBase64);
+
+                // check the decoded byte array is exactly 8 bytes (64 bits),
+                // otherwise it is not a valid 64-bit ID
+                if (bytes.Length != 8)
+                    return false;
+
+                // decode the 8 bytes into a 64-bit long representing the original Id value,
+                // then create a new Id instance from that value.
+                long value = BitConverter.ToInt64(bytes, 0);
+                id = new Id(value);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Attempts to parse a legacy Base64-encoded string (from <see cref="Id.ToStringIdentifier"/>)
+        ///     into an <see cref="Id"/>. Returns true if parsing succeeds; otherwise returns false
+        ///     and sets <paramref name="id"/> to <see cref="default(Id)"/>.
+        /// </summary>
+        /// <param name="base64String">The legacy Base64 string to parse.</param>
+        /// <param name="id">The resulting <see cref="Id"/> if successful; otherwise <see cref="default(Id)"/>.</param>
+        /// <returns>True if the string was successfully parsed into a valid 64-bit ID; false otherwise.</returns>
+        private static bool TryParseFromLegacyBase64(string base64String, out Id id)
+        {
+            id = default;
+
+            try
+            {
+                // decode the Base64 string into a UTF-8 byte array
+                byte[] bytes = Convert.FromBase64String(base64String);
+
+                // convert the byte array into a decimal string representation of the Id
+                string decimalString = Encoding.UTF8.GetString(bytes);
+
+                // try to parse the decimal string into a 64-bit long
+                if (long.TryParse(decimalString, out long value))
+                {
+                    // parsed - create a new Id instance
+                    id = new Id(value);
+                    return true;
+                }
+
+                // failed - string doesn't represent valid long Id
+                return false;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #20.

This PR introduces a new and efficient way to serialize Ids as URL-safe Base64 strings. It includes parsing methods that support both the new format and the legacy `ToStringIdentifier()` Base64 string format, along with unit tests.

Changes included:

- Added `IdExtensions.ToBase64String()` for URL-safe Base64 encoding of 64-bit IDs.
- Replaces `+` and `/` with `-` and `_` for URL safety.
- Removes padding characters (`=`).
- Added `IdExtensions.FromBase64String()` to parse both new URL-safe and legacy Base64 strings.
- Added `TryParseFromUrlSafeBase64()` private helper for safe parsing of the new Base64 format.
- Added `TryParseFromLegacyBase64()` private helper to maintain compatibility with `ToStringIdentifier()`.
- Updated `ToStringIdentifier()` to remain for legacy support and marked it as [Obsolete].

Added unit tests covering:
- Round-trip encoding and decoding for both new and legacy formats.
- URL safety and absence of padding in new format.
- Handling invalid inputs.
- Validation of short output versus legacy format.
- Parsing specific edge-case ID values (0, -1, large values).
- Verification that ToStringIdentifier is correctly marked [Obsolete].

Please let me know what you think or if any changes are needed.