### PR TITLE
Synchronize ID generation to guarantee uniqueness and K-ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Environment Setup
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Build
       run: dotnet build ./src/FlakeId.sln
     - name: Test

--- a/src/FlakeId.Benchmarks/FlakeId.Benchmarks.csproj
+++ b/src/FlakeId.Benchmarks/FlakeId.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FlakeId.Benchmarks/FlakeIdMultipleRuntimesBenchmarks.cs
+++ b/src/FlakeId.Benchmarks/FlakeIdMultipleRuntimesBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnostics.Windows.Configs;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 
 namespace FlakeId.Benchmarks
@@ -8,8 +9,11 @@ namespace FlakeId.Benchmarks
     [SimpleJob(RuntimeMoniker.Net60)]
     [SimpleJob(RuntimeMoniker.Net70)]
     [SimpleJob(RuntimeMoniker.Net80)]
+    [SimpleJob(RuntimeMoniker.Net90)]
+#if _WINDOWS
     [DisassemblyDiagnoser]
     [InliningDiagnoser(true, null)]
+#endif
     public class FlakeIdMultipleRuntimesBenchmarks
     {
         [Benchmark]

--- a/src/FlakeId.Benchmarks/IdCreationBenchmarks.cs
+++ b/src/FlakeId.Benchmarks/IdCreationBenchmarks.cs
@@ -6,8 +6,10 @@ using MassTransit;
 
 namespace FlakeId.Benchmarks
 {
+#if _WINDOWS
     [DisassemblyDiagnoser]
     [InliningDiagnoser(true, null)]
+#endif
     public class IdCreationBenchmarks
     {
         private static readonly IdGenerator s_idGenerator = new IdGenerator(10,
@@ -30,7 +32,7 @@ namespace FlakeId.Benchmarks
         {
             NewId.Next();
         }
-        
+
         [Benchmark]
         public void Single_IdGen()
         {

--- a/src/FlakeId.Tests/ConcurrencyTests.cs
+++ b/src/FlakeId.Tests/ConcurrencyTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FlakeId.Tests;
+
+[TestClass]
+public class ConcurrencyTests
+{
+    private const int ThreadIdBits = 5;
+    private const int ProcessIdBits = 5;
+    private const int IncrementBits = 12;
+    private const int TimestampShift = ThreadIdBits + ProcessIdBits + IncrementBits;
+    private const int IncrementMask = (1 << IncrementBits) - 1;
+
+    private static readonly FieldInfo s_prevIdField =
+        typeof(Id).GetField("s_prevId", BindingFlags.NonPublic | BindingFlags.Static);
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        Assert.IsNotNull(s_prevIdField, "Could not find the private static field 's_prevId' for testing.");
+        s_prevIdField.SetValue(null, 0L);
+    }
+
+    [TestMethod]
+    public void Create_ShouldGenerateNonZeroId()
+    {
+        long id = Id.Create();
+
+        Assert.AreNotEqual(0L, id);
+    }
+
+    [TestMethod]
+    public void Create_ShouldGenerateMonotonicallyIncreasingIds()
+    {
+        const int idCount = 500_000;
+        long[] ids = new long[idCount];
+
+        for (int i = 0; i < idCount; i++)
+        {
+            ids[i] = Id.Create();
+        }
+
+        for (int i = 1; i < idCount; i++)
+        {
+            Assert.IsTrue(ids[i] > ids[i - 1], $"ID at index {i} was not greater than the previous one.");
+        }
+    }
+
+    [TestMethod]
+    public void Create_ShouldGenerateUniqueIds_WhenCalledConcurrently()
+    {
+        const int idsPerTask = 100_000;
+        int taskCount = Environment.ProcessorCount;
+        int totalIds = idsPerTask * taskCount;
+        var generatedIds = new ConcurrentBag<long>();
+
+        var tasks = new List<Task>();
+
+        for (int i = 0; i < taskCount; i++)
+        {
+            tasks.Add(Task.Run(() =>
+            {
+                for (int j = 0; j < idsPerTask; j++)
+                {
+                    generatedIds.Add(Id.Create());
+                }
+            }));
+        }
+
+        Task.WaitAll(tasks.ToArray());
+
+        Assert.AreEqual(totalIds, generatedIds.Count, "The number of generated IDs does not match the expected total.");
+
+        var distinctIds = new HashSet<long>(generatedIds);
+        Assert.AreEqual(totalIds, distinctIds.Count, "Duplicate IDs were found when generating concurrently.");
+    }
+
+    [TestMethod]
+    public void Create_ShouldThrow_WhenClockMovesBackwards()
+    {
+        Assert.IsNotNull(s_prevIdField, "Could not find the private static field 's_prevId' for testing.");
+
+        long baseId = Id.Create();
+        long baseTimestamp = baseId >> TimestampShift;
+
+        long futureTimestamp = baseTimestamp + 5000;
+        long futureId = futureTimestamp << TimestampShift;
+        s_prevIdField.SetValue(null, futureId);
+
+        var ex = Assert.ThrowsException<InvalidOperationException>(() => Id.Create());
+        StringAssert.Contains(ex.Message, "Clock shifted backwards");
+    }
+
+    [TestMethod]
+    public void Increment_ShouldResetToZero_OnNewMillisecond()
+    {Assert.IsNotNull(s_prevIdField, "Could not find the private static field 's_prevId' for testing.");
+
+        long baseId = Id.Create();
+        long baseTimestamp = baseId >> TimestampShift;
+
+        // create a fake "previous ID" that is at the same timestamp but has a high increment.
+        // we preserve the other parts of the ID (thread, process) to make the state realistic.
+        const int highIncrement = 4000;
+        long otherParts = baseId & ~((1L << 42) - 1); // masks out the timestamp
+        long prevId = otherParts | (baseTimestamp << TimestampShift) | highIncrement;
+
+        s_prevIdField.SetValue(null, prevId);
+
+        Thread.Sleep(5);
+
+        long newIdValue = Id.Create();
+
+        long newTimestamp = newIdValue >> TimestampShift;
+        int newIncrement = (int)(newIdValue & IncrementMask);
+
+        Assert.IsTrue(newTimestamp > baseTimestamp, "Timestamp should have advanced.");
+        Assert.AreEqual(0, newIncrement, "Increment should reset to 0 on a new millisecond.");
+    }
+}

--- a/src/FlakeId.Tests/FlakeId.Tests.csproj
+++ b/src/FlakeId.Tests/FlakeId.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
+
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FlakeId.Tests/IdTests.cs
+++ b/src/FlakeId.Tests/IdTests.cs
@@ -90,14 +90,5 @@ namespace FlakeId.Tests
 
             Assert.AreEqual(id.ToString(), id.ToString());
         }
-
-        [TestMethod]
-        public void Id_ContainsTimeZoneComponent()
-        {
-            DateTimeOffset timeStamp = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.FromHours(7));
-            Id id = Id.Create(timeStamp.ToUnixTimeMilliseconds());
-
-            Assert.AreEqual(timeStamp.ToUnixTimeMilliseconds(), id.ToUnixTimeMilliseconds());
-        }
     }
 }

--- a/src/FlakeId/FlakeId.csproj
+++ b/src/FlakeId/FlakeId.csproj
@@ -16,6 +16,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>FlakeId.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\assets\snowflake-96.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>

--- a/src/FlakeId/FlakeId.csproj
+++ b/src/FlakeId/FlakeId.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Discord inspired, Twitter like implementation of Snowflake IDs, focused on performance. Snowflakes are 64 bit, highly optimized, decentralized, K-ordered, unique identifiers.</Description>
     <RepositoryUrl>https://github.com/aevitas/flakeid</RepositoryUrl>

--- a/src/FlakeId/Id.cs
+++ b/src/FlakeId/Id.cs
@@ -21,7 +21,7 @@ namespace FlakeId
         // 111111111111111111111111111111111111111111  11111  11111 111111111111
         // 64                                          22     17    12          0
         //
-        // The Timestamp component is represented as the milliseconds since the first second of 2015. 
+        // The Timestamp component is represented as the milliseconds since the first second of 2015.
         // Since we're using all 64 bits available, this epoch can be any point in time, as long as it's in the past.
         // If the epoch is set to a point in time in the future, it may result in negative snowflakes being generated.
         //
@@ -30,11 +30,11 @@ namespace FlakeId
         // the closest we can get to the original specification within the .NET ecosystem.
         //
         // The Increment component is a monotonically incrementing number, which is incremented every time a snowflake is generated.
-        // This is in contrast with some other flake-ish implementations, which only increment the counter any time a snowflake is 
+        // This is in contrast with some other flake-ish implementations, which only increment the counter any time a snowflake is
         // generated twice at the exact same instant in time. We believe Discord's implementation is more correct here,
         // as even two snowflakes that are generated at the exact same point in time will not be identical, because of their increments.
         //
-        // This implementation is optimised for high-throughput applications, while providing IDs that are roughly sortable, and 
+        // This implementation is optimised for high-throughput applications, while providing IDs that are roughly sortable, and
         // with a very high degree of uniqueness.
 
         private long _value;
@@ -71,7 +71,7 @@ namespace FlakeId
         }
 
         /// <summary>
-        ///     Creates a new ID based on the provided timestamp in milliseconds. 
+        ///     Creates a new ID based on the provided timestamp in milliseconds.
         ///     When using this overload, make sure you take the timezone of the provided timestamp into consideration.
         /// </summary>
         /// <param name="timeStampMs"></param>
@@ -87,7 +87,7 @@ namespace FlakeId
             Id id = new Id();
             long relativeTimeStamp = timeStampMs - MonotonicTimer.Epoch.ToUnixTimeMilliseconds();
 
-            if (relativeTimeStamp < 0) 
+            if (relativeTimeStamp < 0)
             {
                 throw new ArgumentException("Specified timestamp would result in a negative ID (it's before instance epoch)");
             }
@@ -141,8 +141,8 @@ namespace FlakeId
         {
             long milliseconds = timeStampMs == 0 ? MonotonicTimer.ElapsedMilliseconds : timeStampMs;
             long timestamp = milliseconds & TimestampMask;
-            int threadId = Thread.CurrentThread.ManagedThreadId & ThreadIdMask;
-            // int processId = s_processId ??= Process.GetCurrentProcess().Id & ProcessIdMask;
+            int threadId = Environment.CurrentManagedThreadId & ThreadIdMask;
+
             if (s_processId is null)
                 s_processId = Process.GetCurrentProcess().Id & ProcessIdMask;
             int processId = s_processId.Value;

--- a/src/FlakeId/Id.cs
+++ b/src/FlakeId/Id.cs
@@ -9,7 +9,7 @@ namespace FlakeId
     ///     Represents a unique, K-ordered, sortable identifier.
     /// </summary>
     [DebuggerDisplay("{_value}")]
-    public struct Id : IComparable<Id>
+    public struct Id : IComparable<Id>, IEquatable<Id>
     {
         // This implementation of Snowflake ID is based on the specification as published by Discord:
         // https://discord.com/developers/docs/reference


### PR DESCRIPTION
Fixes #23 #24 and #25 -- see these issues for more details.

This pull request implements synchronization (without locking!) around the last generated ID, ensuring subsequent IDs are both unique, and sortable.

Implementing these changes brings the implementation more in line with established Snowflake guidelines.