### PR TITLE
Change IsSnowflake to only look for a timestamp

### DIFF
--- a/src/FlakeId/Extensions/IdExtensions.cs
+++ b/src/FlakeId/Extensions/IdExtensions.cs
@@ -34,15 +34,11 @@ namespace FlakeId.Extensions
         /// <returns></returns>
         public static bool IsSnowflake(this Id id)
         {
-            // There's no way to guarantee the specified value is a snowflake.
-            // The closest we can get is by decomposing its components, and ensuring all of them are set
-            // to values that would be valid for a snowflake.
+            // Validates that the ID has a non-zero timestamp.
+            // Thread , Process, and Increment can legitimately be 0, so checking them for > 0 results in false negatives.
             long timestamp = id >> TimestampOffset;
-            long thread = (id >> ThreadOffset) & Id.ThreadIdMask;
-            long process = (id >> ProcessOffset) & Id.ProcessIdMask;
-            long increment = id & Id.IncrementMask;
 
-            return timestamp > 0 && thread > 0 && process > 0 && increment >= 0;
+            return timestamp > 0;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #19 by changing `IsSnowflake` to only look for the timestamp component, as the others can legitimately be 0 after masking. This should improve compatibility with Discord generated snowflakes especially.